### PR TITLE
Add starter backtesting module using backtesting library

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ source .venv/bin/activate
 pip install \
   pandas numpy matplotlib tqdm requests ratelimit yfinance \
   scipy scikit-posthocs plotly sec-api beautifulsoup4 \
-  polygon-api-client SQLAlchemy mysql-connector-python finvizfinance
+  polygon-api-client SQLAlchemy mysql-connector-python finvizfinance \
+  backtesting
 ```
 
 3) Make the package importable
@@ -146,6 +147,18 @@ print(ratings)
 ```
 Note: The `seeking_alpha` module loads local caches on import in its current state. See Caveats to run it without Windows paths.
 
+- **6) Simple backtest with the `backtesting` library**
+```python
+from market_data.backtesting_module import run_backtest, SmaCross
+from market_data.price_data_import import api_import
+
+data = api_import(["AAPL"], from_date="2024-01-01")
+df = data["AAPL"]
+
+backtest, stats = run_backtest(df, strategy=SmaCross)
+print(stats[["Return [%]", "Sharpe Ratio", "# Trades"]])
+```
+
 
 ## Modules
 - `price_data_import.py`
@@ -168,6 +181,7 @@ Note: The `seeking_alpha` module loads local caches on import in its current sta
 
 - Additional modules
   - `anchored_vwap.py`: Utilities for anchored VWAP calculations.
+  - `backtesting_module.py`: Helpers for running strategy backtests using the `backtesting` library.
   - `watchlist_filters.py`: Plotting and screening utilities (uses `finvizfinance`, `plotly`, and `matplotlib`).
   - `regimes.py`, `episodic_pivots.py`, `intraday_study.py`, etc.: Exploratory studies and specialized analytics.
 
@@ -202,4 +216,3 @@ Note: The `seeking_alpha` module loads local caches on import in its current sta
 - Yahoo Finance (via `yfinance`) and Finviz tooling.
 
 If you have questions or need help adapting paths for your environment, consider opening an issue with details about your OS, Python version, and the exact error/traceback.
-

--- a/backtesting_module.py
+++ b/backtesting_module.py
@@ -1,0 +1,85 @@
+"""Helpers for running strategies with the backtesting library."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Tuple, Type
+
+import pandas as pd
+from backtesting import Backtest, Strategy
+from backtesting.lib import crossover
+from backtesting.test import SMA
+
+
+REQUIRED_OHLCV_COLUMNS = ("Open", "High", "Low", "Close", "Volume")
+
+
+def normalize_ohlcv(
+    df: pd.DataFrame, column_map: Optional[Dict[str, str]] = None
+) -> pd.DataFrame:
+    """Return a DataFrame with the OHLCV columns required by backtesting.
+
+    Args:
+        df: Source data.
+        column_map: Optional mapping of existing column names to the required
+            OHLCV column names. Example: {"open": "Open", "close": "Close"}.
+    """
+    if column_map:
+        df = df.rename(columns=column_map)
+    else:
+        lower_map = {col.lower(): col for col in df.columns}
+        rename: Dict[str, str] = {}
+        for col in ("open", "high", "low", "close", "volume"):
+            if col in lower_map:
+                rename[lower_map[col]] = col.title()
+        df = df.rename(columns=rename)
+
+    missing = [col for col in REQUIRED_OHLCV_COLUMNS if col not in df.columns]
+    if missing:
+        raise ValueError(
+            "Missing required OHLCV columns after normalization: "
+            f"{', '.join(missing)}"
+        )
+
+    return df[list(REQUIRED_OHLCV_COLUMNS)].copy()
+
+
+class SmaCross(Strategy):
+    """Simple SMA crossover example strategy."""
+
+    n1 = 10
+    n2 = 20
+
+    def init(self) -> None:
+        close = self.data.Close
+        self.sma1 = self.I(SMA, close, self.n1)
+        self.sma2 = self.I(SMA, close, self.n2)
+
+    def next(self) -> None:
+        if crossover(self.sma1, self.sma2):
+            self.buy()
+        elif crossover(self.sma2, self.sma1):
+            self.sell()
+
+
+def run_backtest(
+    df: pd.DataFrame,
+    strategy: Type[Strategy] = SmaCross,
+    cash: float = 10_000,
+    commission: float = 0.0,
+    column_map: Optional[Dict[str, str]] = None,
+    **kwargs: Any,
+) -> Tuple[Backtest, pd.Series]:
+    """Run a backtest and return the Backtest instance plus stats.
+
+    Args:
+        df: Input OHLCV data.
+        strategy: Backtesting Strategy class.
+        cash: Starting cash.
+        commission: Commission percentage (0.002 = 0.2%).
+        column_map: Optional mapping for OHLCV columns.
+        **kwargs: Extra Backtest keyword arguments (e.g., exclusive_orders).
+    """
+    data = normalize_ohlcv(df, column_map=column_map)
+    backtest = Backtest(data, strategy, cash=cash, commission=commission, **kwargs)
+    stats = backtest.run()
+    return backtest, stats

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ setup(
     version="0.1.0",
     packages=find_packages(),    # will pick up the `market_data` package
     install_requires=[
+        "backtesting",
         # e.g. "pandas>=1.2", "numpy"
     ],
     entry_points={


### PR DESCRIPTION
### Motivation
- Provide a minimal, opinionated starting point for running strategy backtests in the project using the `backtesting` library.
- Make it easy to feed existing OHLCV data into the backtesting tools by normalizing column names and offering a simple example strategy.
- Document usage and ensure the dependency is declared for packaging.

### Description
- Add `backtesting_module.py` which provides `normalize_ohlcv`, an example `SmaCross` `Strategy`, and a `run_backtest` helper that returns the `Backtest` instance and stats.
- Update `README.md` with installation instructions including `backtesting` and a short usage example showing `run_backtest` and `SmaCross` with `api_import` data.
- Update `setup.py` to include `backtesting` in `install_requires` so the package metadata reflects the new dependency.

### Testing
- No automated tests were run as part of this change.
- Changes were committed to the repository and the new module is importable; further automated tests or CI integration can be added in follow-up work.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980d220cf24832a8525c503d23bf55c)